### PR TITLE
Added test for two servo intake

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/DualServoIntakeTest.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/DualServoIntakeTest.kt
@@ -1,0 +1,22 @@
+package org.firstinspires.ftc.teamcode.opmodes
+
+import com.qualcomm.robotcore.eventloop.opmode.TeleOp
+import org.firstinspires.ftc.teamcode.internals.base.BaseOpMode
+import org.firstinspires.ftc.teamcode.scripts.ContinuousServoScript
+
+@TeleOp(group = BaseOpMode.DEBUG_GROUP_NAME)
+class DualServoIntakeTest : BaseOpMode() {
+    override fun construct() {
+        addScript(ContinuousServoScript(id = 0, inverted = true))
+        addScript(ContinuousServoScript(id = 1, inverted = false))
+    }
+
+    override fun run() {
+
+    }
+
+    override fun onStop() {
+
+    }
+
+}


### PR DESCRIPTION
Before issuing a pull request, please see the documentation on [https://robotics.xbhs.net/branches](https://robotics.xbhs.net/branches)
for more information.



(put what you changed here)
I push a opmode that uses the continuous servo script.


(put how to use your code here)
Servo ports 0 and 1 
left and right triggers for usage. Special for the intake to pick up blocks.
**Reviewers:**

@XaverianTeamRobotics/senior-programmers
