### PR TITLE
Add Android CI and Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+
+  - package-ecosystem: gradle
+    directory: /
+    schedule:
+      interval: daily

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -2,10 +2,8 @@ name: Android CI
 
 on:
   push:
-    branches: [ "master" ]
   pull_request:
-    branches: [ "master" ]
-
+  
 jobs:
   build:
 

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,26 @@
+name: Android CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: gradle
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Build with Gradle
+      run: ./gradlew build

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -6,7 +6,6 @@ on:
   
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
@@ -21,4 +20,9 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle
-      run: ./gradlew build
+      run: ./gradlew :TeamCode:assemble
+    - name: Upload APK
+      uses: actions/upload-artifact@v4.4.3
+      with:
+        name: TeamCode-debug.apk
+        path: ./TeamCode/build/outputs/apk/debug/TeamCode-debug.apk


### PR DESCRIPTION
Add Android CI and Dependabot.

Android CI will run on every push or pr.
Dependabot will run every day for the Gradle dependencies
